### PR TITLE
Implement websocket reconnect logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,19 @@ class App {
     }
 
     start() {
+        this.setupWebsocket();
+        this.fetchTask = setInterval(async () => {
+            console.log("Fetching data");
+            const json = await fetchJson(this.jvbUrl);
+            this.processJvbJson(json);
+        }, 5000);
+    }
+
+    stop() {
+        clearInterval(this.fetchTask);
+    }
+
+    setupWebsocket() {
         // Create the websocket client
         this.wsClient = new WebSocketClient({
             keepalive: true,
@@ -63,15 +76,6 @@ class App {
 
         // Do the initial connection
         wsConnectionFunction();
-        this.fetchTask = setInterval(async () => {
-            console.log("Fetching data");
-            const json = await fetchJson(this.jvbUrl);
-            this.processJvbJson(json);
-        }, 5000);
-    }
-
-    stop() {
-        clearInterval(this.fetchTask);
     }
 
     processJvbJson(jvbJson) {


### PR DESCRIPTION
This PR implements reconnecting the websocket if it fails for any reason.  A couple notes:

1) Any time the websocket fails, the code will try to reconnect after 5 seconds.  It will do this infinitely, in the interest of simplicity.
2) Any messages that are attempted to be sent during this time are lost.  This is obviously not ideal, but I think this is a good first step in the right direction.  We'll need to figure out how we want to handle data that is 'dropped' when the websocket is down: stats data is likely fine to drop, but the creation of new sessions, for example, would be important to re-attempt and would need to be sent before any stats data for that session.  I'll take a look at doing something about that in a subsequent PR.