### PR TITLE
use shard wide unique meeting id

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,7 +98,7 @@ class App {
             const confState = {
                 statsSessionId,
                 confName: extractConferenceName(jvbJson, newConfId),
-                meetingUniqueId: extractUniqueMeetingId(jvbJson, newConfId),
+                meetingUniqueId: extractUniqueMeetingId(jvbJson, newConfId) || newConfId,
                 applicationName: 'JVB',
                 endpoints: []
             }

--- a/app.js
+++ b/app.js
@@ -98,7 +98,7 @@ class App {
             const confState = {
                 statsSessionId,
                 confName: extractConferenceName(jvbJson, newConfId),
-                meetingUniqueId: newConfId,
+                meetingUniqueId: extractUniqueMeetingId(jvbJson, newConfId),
                 applicationName: 'JVB',
                 endpoints: []
             }
@@ -182,6 +182,10 @@ async function fetchJson(url) {
 
 function extractConferenceName(jvbJson, confId) {
     return jvbJson.conferences[confId].name.split('@')[0];
+}
+
+function extractUniqueMeetingId(jvbJson, confId) {
+    return jvbJson.conferences[confId].meeting_id;
 }
 
 function createIdentityMessage(state) {


### PR DESCRIPTION
We need to use [this](https://github.com/jitsi/jitsi-videobridge/blob/1117daf171171a82186b02c114c405c7349c4c50/jvb/src/main/java/org/jitsi/videobridge/Conference.java#L174) meeting id for proper grouping in the rtcstats visualizer.