### PR TITLE
Fix handling json when some conferences have rtcstatsEnabled=false

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,9 +171,13 @@ function getConferenceIds (jvbJson) {
   // only report conferences that have rtcstats enabled. Note that we include conferences that don't have the
   // rtcstatsEnabled flag set in order to maintain backwards compatibility with bridges that don't support this
   // new flag.
+  // We also filter out conferences that don't have the name set. In practice this just ignores conferences
+  // created with REST to make sure the JVB IP has been initialized.
   return Object.keys(jvbJson.conferences)
-    .filter(confId => jvbJson.conferences[confId].rtcstatsEnabled === undefined ||
-            jvbJson.conferences[confId].rtcstatsEnabled)
+    .filter(confId => {
+      const conf = jvbJson.conferences[confId];
+      return (conf.rtcstatsEnabled == undefined || conf.rtcstatsEnabled) && conf.name
+  })
 }
 
 async function fetchJson (url) {

--- a/app.js
+++ b/app.js
@@ -81,7 +81,7 @@ class App {
   processJvbJson (jvbJson) {
     this.checkForAddedOrRemovedConferences(jvbJson)
     const timestamp = jvbJson.time
-    Object.keys(jvbJson.conferences).forEach(confId => {
+    getConferenceIds(jvbJson).forEach(confId => {
       const confData = jvbJson.conferences[confId]
       // The timestamp is at the top level, inject it into the conference data here
       confData.timestamp = timestamp
@@ -175,9 +175,9 @@ function getConferenceIds (jvbJson) {
   // created with REST to make sure the JVB IP has been initialized.
   return Object.keys(jvbJson.conferences)
     .filter(confId => {
-      const conf = jvbJson.conferences[confId];
-      return (conf.rtcstatsEnabled == undefined || conf.rtcstatsEnabled) && conf.name
-  })
+      const conf = jvbJson.conferences[confId]
+      return (conf.rtcstatsEnabled === undefined || conf.rtcstatsEnabled) && conf.name
+    })
 }
 
 async function fetchJson (url) {


### PR DESCRIPTION
- Ignore conferences with no "name" set.
- fix: Do not processConference() for entries with rtcstatsEnabled=false.
